### PR TITLE
MEC-699 : Add default community pull request template.

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,13 @@
+Why this PR is needed
+----
+Add a sentence or two on the reason this PR exists. Remember that the reviewer likely doesn't have as much context as you. Help them help you.
+
+Jira ticket reference : [PROJECT-XXX](https://energyhub.atlassian.net/browse/PROJECT-XXX)
+
+What this PR includes
+----
+Brief description of what was done to meet the PR goal.
+
+How to test / verify these changes
+----
+This is an optional section! Only include it if applicable.


### PR DESCRIPTION
Why this PR is needed
----
We have several copies of a PR template sprinkled across repositories. Instead of heaving a copy for each repo, we should make a default available.

Jira ticket reference : [MEC-699](https://energyhub.atlassian.net/browse/MEC-699)

What this PR includes
----
A PR template file.

How to test / verify these changes
----
Steps:
- create a PR in a repo that does not have a PR template
- observe that the PR is populated with the default PR template