### PR TITLE
MEC-727 : upload application jar

### DIFF
--- a/.github/workflows/maven-build-lifecycle.yml
+++ b/.github/workflows/maven-build-lifecycle.yml
@@ -11,6 +11,15 @@ on:
         required: true
       AWS_SECRET_ACCESS_KEY:
         required: true
+    inputs:
+      upload-artifacts:
+        required: false
+        default: false
+        type: boolean
+      application-path:
+        required: false
+        default: server
+        type: string
 
 env:
   AWS_REGION: us-east-1
@@ -57,3 +66,11 @@ jobs:
 
       - name: Build and Run tests
         run:  mvn verify
+
+      - name: Upload application jar
+        if: ${{ inputs.upload-artifacts }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.application-path }}
+          path: ${{ inputs.application-path }}/target/*.jar
+          retention-days: 14


### PR DESCRIPTION
Why this PR is needed
----
The application jar needs to be optionally uploaded in the reusable workflow so it can be used for the deploy stage.

Jira ticket reference : [MEC-727](https://energyhub.atlassian.net/browse/MEC-727)

What this PR includes
----
- Adds a flag to store artifacts. If true uploads the application jar at the specified path 