### PR TITLE
MEC-1027 : add starter workflow for dependabot auto-merge

### DIFF
--- a/workflow-templates/dependabot-auto-merge.properties.json
+++ b/workflow-templates/dependabot-auto-merge.properties.json
@@ -1,0 +1,8 @@
+{
+  "name": "Dependabot Auto Merge Workflow",
+  "description": "Automatically approve and enable auto-merge for dependabot PRs which include patch or minor version upgrades.",
+  "iconName": "energyhub-logo",
+  "categories": [
+    "Automation"
+  ]
+}

--- a/workflow-templates/dependabot-auto-merge.yml
+++ b/workflow-templates/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+# This workflow will automatically approve and enable auto-merge for pull requests created by dependabot.
+# It will skip these actions for PRs which include a major version upgrade, as determined by semantic versioning.
+# To use this in a repository, ensure the following:
+#   1. "Allow auto-merge" is enabled https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository
+#   2. At least one automated status check is required before merge. This is configured via branch protection rules.
+name: Dependabot PR approval and auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/dependabot-auto-merge.yml
+++ b/workflow-templates/dependabot-auto-merge.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.1.1
+        uses: dependabot/fetch-metadata@v1.3.3
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve a PR


### PR DESCRIPTION
Why this PR is needed
----
We can ease the maintenance burden of projects significantly if we allow Dependabot to automatically merge patch and minor version upgrades (if the upgrades passed continuous integration checks). Developers will still be required to review Dependabot PRs which include major version upgrades, or fail continuous integration.

Jira ticket reference : [MEC-1027](https://energyhub.atlassian.net/browse/MEC-1027)

What this PR includes
----
- includes a starter workflow to enable developers to incorporate this practice into their repository

How to test / verify these changes
----
This workflow was applied in the [base-pom repository](https://github.com/energyhub/base-pom/pull/24) and has been working well! 