### PR TITLE
MEC-1027 : consolidate workflow management for dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,38 @@
+# This workflow will automatically approve and enable auto-merge for pull requests created by dependabot.
+# It will skip these actions for PRs which include a major version upgrade, as determined by semantic versioning.
+# To use this in a repository, ensure the following:
+#   1. "Allow auto-merge" is enabled https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-auto-merge-for-pull-requests-in-your-repository
+#   2. At least one automated status check is required before merge. This is configured via branch protection rules.
+name: Dependabot PR approval and auto-merge
+on:
+  workflow_call:
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve a PR
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflow-templates/dependabot-auto-merge.yml
+++ b/workflow-templates/dependabot-auto-merge.yml
@@ -12,5 +12,6 @@ permissions:
 
 jobs:
   dependabot:
+    if: ${{ github.actor == 'dependabot[bot]' }}
     uses: energyhub/.github/.github/workflows/dependabot-auto-merge.yml@main
     secrets: inherit

--- a/workflow-templates/dependabot-auto-merge.yml
+++ b/workflow-templates/dependabot-auto-merge.yml
@@ -12,23 +12,5 @@ permissions:
 
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
-    steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v1.3.3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve a PR
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: energyhub/.github/.github/workflows/dependabot-auto-merge.yml@main
+    secrets: inherit


### PR DESCRIPTION
Why this PR is needed
----
Create a reusable workflow to reference for the dependabot auto merge workflow. That way, if anything changes, the workflow can be modified in a single place. 

Jira ticket reference : [MEC-1027](https://energyhub.atlassian.net/browse/MEC-1027)

What this PR includes
----
- adds a reusable workflow. 
- references from a starter workflow 
