### PR TITLE
MEC-1034 : github token is made available to reusable workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -6,9 +6,6 @@
 name: Dependabot PR approval and auto-merge
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        required: true
 
 permissions:
   contents: write


### PR DESCRIPTION
Why this PR is needed
----
In implementing a reusable dependabot workflow, I missed the following information regarding secrets:

> When a reusable workflow is triggered by a caller workflow, the github context is always associated with the caller workflow. The called workflow is automatically granted access to github.token and secrets.GITHUB_TOKEN. 

Specifying this secret results in an error. 

Jira ticket reference : [MEC-1034](https://energyhub.atlassian.net/browse/MEC-1034)

What this PR includes
----
- removes specifying the github token 