### PR TITLE
CATS-3: run maven in non-interactive mode to reduce output

### DIFF
--- a/.github/workflows/maven-build-lifecycle.yml
+++ b/.github/workflows/maven-build-lifecycle.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Build and Run tests
         env:
           OCI_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: mvn verify
+        run: mvn -B verify
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
Why this PR is needed
----
There that can be a lot of noise in the GH actions log during Maven builds especially when dependencies are being downloaded (see attached screenshot).  This PR reduces that without losing pertinent build information.

Jira ticket reference : [CATS-3](https://energyhub.atlassian.net/browse/CATS-3)

What this PR includes
----
Added `-B` flag to `mvn verify` command to run Maven in non-interactive mode.

How to test / verify these changes
----
Builds don't break and log noise is reduced during Maven build.

![image](https://user-images.githubusercontent.com/12024120/193653764-0a27d916-e2d6-423d-a861-00507b67ae73.png)
