### PR TITLE
CAT-49 : Don't use secret for jfrog user

### DIFF
--- a/.github/actions/maven-setup/action.yml
+++ b/.github/actions/maven-setup/action.yml
@@ -2,10 +2,10 @@ name: "Setup Maven"
 description: "Setup JDK 17, maven cache, and JFrog credentials"
 
 inputs:
-  jfrog_user:
+  jfrog-user:
     description: JFrog username used to create the access key (password)
     required: true
-  jfrog_password:
+  jfrog-password:
     description: JFrog access key (password)
     required: true
 
@@ -57,12 +57,12 @@ runs:
           [
             {
               "id": "releases",
-              "username": "${{ inputs.jfrog_user }}",
-              "password": "${{ inputs.jfrog_password }}"
+              "username": "${{ inputs.jfrog-user }}",
+              "password": "${{ inputs.jfrog-password }}"
             },
             {
               "id": "snapshots",
-              "username": "${{ inputs.jfrog_user }}",
-              "password": "${{ inputs.jfrog_password }}"
+              "username": "${{ inputs.jfrog-user }}",
+              "password": "${{ inputs.jfrog-password }}"
             }
           ]

--- a/.github/workflows/maven-build-lifecycle.yml
+++ b/.github/workflows/maven-build-lifecycle.yml
@@ -3,8 +3,6 @@ name: Run Maven Build Lifecycle
 on:
   workflow_call:
     secrets:
-      JFROG_USER:
-        required: true
       JFROG_PASSWORD:
         required: true
       AWS_ACCESS_KEY_ID:
@@ -29,6 +27,9 @@ on:
       application-path:
         required: false
         default: server
+        type: string
+      jfrog-user:
+        required: true
         type: string
     outputs:
       revision:
@@ -56,8 +57,8 @@ jobs:
       - name: Maven Setup
         uses: energyhub/.github/.github/actions/maven-setup@main
         with:
-          jfrog_user: ${{ secrets.JFROG_USER }}
-          jfrog_password: ${{ secrets.JFROG_PASSWORD }}
+          jfrog-user: ${{ inputs.jfrog-user }}
+          jfrog-password: ${{ secrets.JFROG_PASSWORD }}
 
       - name: Set a revision number
         id: resolve-revision


### PR DESCRIPTION
Why this PR is needed
----
See https://github.com/energyhub/base-pom/pull/83

Jira ticket reference : [CAT-49](https://energyhub.atlassian.net/browse/CAT-49)

What this PR includes
----
- change input names from using `_` to `-` to follow github actions conventions
- change jfrog user from secret to input

How to test / verify these changes
----
Tested in https://github.com/energyhub/base-pom/pull/83 and https://github.com/energyhub/java-microservice-template/pull/40