### PR TITLE
CAT-49 : Resolve deprecation warnings

### DIFF
--- a/.github/workflows/aws-ecs-deploy.yml
+++ b/.github/workflows/aws-ecs-deploy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/aws_ecs_deploy.yml
+++ b/.github/workflows/aws_ecs_deploy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/aws_ecs_deploy.yml
+++ b/.github/workflows/aws_ecs_deploy.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/maven-build-lifecycle.yml
+++ b/.github/workflows/maven-build-lifecycle.yml
@@ -93,7 +93,7 @@ jobs:
           # be deployed to ECS.
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ${{ inputs.application-path }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          run: echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Upload artifacts from workflow
         if: ${{ inputs.artifact-paths != '' && inputs.upload-artifacts }}

--- a/.github/workflows/maven-build-lifecycle.yml
+++ b/.github/workflows/maven-build-lifecycle.yml
@@ -62,10 +62,10 @@ jobs:
 
       - name: Set a revision number
         id: resolve-revision
-        run: echo "::set-output name=revision::$(source ./etc/ci/get_revision.sh && get_revision .)"
+        run: echo "revision=$(source ./etc/ci/get_revision.sh && get_revision .)" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -93,7 +93,7 @@ jobs:
           # be deployed to ECS.
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG ${{ inputs.application-path }}
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image-tag::$IMAGE_TAG"
+          run: echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
       - name: Upload artifacts from workflow
         if: ${{ inputs.artifact-paths != '' && inputs.upload-artifacts }}


### PR DESCRIPTION
Why this PR is needed
----
Two deprecation warnings were [appearing](https://github.com/energyhub/java-microservice-template/actions/runs/3603380342): (1) set-output command is deprecated and (2) node12 is deprecated.

Jira ticket reference : [CAT-49](https://energyhub.atlassian.net/browse/CAT-49)

What this PR includes
----
- aws-configure-credentials [recommends](https://github.com/aws-actions/configure-aws-credentials#notice-node12-deprecation-warning) using their node 16 tag, which will be updated along with v1
- GitHub [recommends](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) using `echo "{name}={value}" >> $GITHUB_OUTPUT` instead of `echo "::set-output name={name}::{value}"`

How to test / verify these changes
----
This was tested in [jmt](https://github.com/energyhub/java-microservice-template/actions/runs/3624283646/jobs/6111086814).