### PR TITLE
MEC-1249: Add git-hook to prepend JIRA ticket to commit title

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Retrieve the ticket number from the branch name
+# 1. Get name of current branch as refs/heads/<branch-name>
+# 2. Cut '/' to retain only 3rd element
+# 3. Grep for '<letters>[_-]<digits>'
+# 4. Preserve only the first match of the previous pattern
+# 5. Capitalize letters & replace '_' with '-'
+ISSUE_NUMBER=$(git symbolic-ref HEAD | cut -d/ -f3 | grep -Eo "^[a-zA-Z]+[_-][0-9]+" | head -1 | tr "[a-z]_" "[A-Z]-")
+
+# If the git commit message template (i.e. $1) does not contain the ticket name + number (happens when amending)
+# then replace the first line, with the value extracted from the branch name
+grep -q "$ISSUE_NUMBER" "$1" || sed -i -e '1 s/\(.*\)/'"$ISSUE_NUMBER"' : \1/' "$1"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gh release create "${DOT_GITHUB_VERSION}" -t "${DOT_GITHUB_VERSION}" --generate-
 
 ## Git Hooks
 
-The folder `.githooks' holds useful
+The folder `.githooks` holds useful
 [git hooks](https://git-scm.com/docs/githooks) that can be reused in any of our
 repos.
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ git pull
 git tag -a "${DOT_GITHUB_VERSION}" -m "Add fun new action"
 gh release create "${DOT_GITHUB_VERSION}" -t "${DOT_GITHUB_VERSION}" --generate-notes -R energyhub/.github
 ```
+
+## Git Hooks
+
+The folder `.githooks' holds useful
+[git hooks](https://git-scm.com/docs/githooks) that can be reused in any of our
+repos.
+
+To install them you'll need [git v2.9 or higher](https://github.com/git/git/blob/master/Documentation/RelNotes/2.9.0.txt#L127-L128)
+copy the `.githooks` folder to the repo of your choice and run `git config core.hooksPath .githooks/` from within that repo.


### PR DESCRIPTION
Why this PR is needed
----
Do you remember which ticket you're currently working on? Probably not,
but fear not for this prepare-commit-msg hook is here to help!

Jira ticket reference : [MEC-1249](https://energyhub.atlassian.net/browse/MEC-1249)

What this PR includes
----
This hook (https://git-scm.com/docs/githooks#_prepare_commit_msg) is
invoked after preparing the default log message (i.e. loading a
potential commit template or '-m' value) and before opening the editor. It allows us
to manipulate the entire commit message (i.e. its title and
description).

The JIRA ticket is extracted from the current branch and prepended to
the first line of the commit message. "$1" represents the file in which the commit message as been placed, either from reading from the git commit template or from the value of
the '-m' option.

Tests I have conducted:
- 'git commit -m "<MSG>"' - JIRA ticket prepended
- 'git commit + editor' - JIRA ticket prepended
- and you guest it this commit was done using this hook!

It was suggested by [Britney](https://github.com/energyhub/mercury-edge-connect/pull/951#pullrequestreview-1214956238) that this be added to this repo after I set it up for MEC.

How to test / verify these changes
----
- make a simple modification
- commit the changed file
- remove the test commit
e.g. `echo $USER >> .gitignore && git commit -m "it's just a test Bert" .gitignore && git reset --hard HEAD^`