### PR TITLE
DEVOPS-1187 : replacing the aws credentials configuration with intern…

### DIFF
--- a/.github/workflows/aws-ecs-deploy.yml
+++ b/.github/workflows/aws-ecs-deploy.yml
@@ -4,11 +4,6 @@ name: Blue Green Deploy via AWS CodeDeploy
 
 on:
   workflow_call:
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
     inputs:
       environment:
         required: true
@@ -22,8 +17,9 @@ on:
         required: true
         type: string
 
-env:
-  AWS_REGION: us-east-1
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   blue-green-deploy:
@@ -34,12 +30,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+      - name: Assume Actions IAM Role  
+        uses: energyhub/workflow-actions/assume-actions-role@v2.4.2
 
       - name: Deploy to AWS ECS
         run: ./etc/ci/deploy.sh "${{ inputs.vpc }}" "${{ inputs.image-tag }}"

--- a/.github/workflows/aws_ecs_deploy.yml
+++ b/.github/workflows/aws_ecs_deploy.yml
@@ -4,11 +4,6 @@ name: Blue Green Deploy via AWS CodeDeploy
 
 on:
   workflow_call:
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
     inputs:
       environment:
         required: true
@@ -22,8 +17,9 @@ on:
         required: true
         type: string
 
-env:
-  AWS_REGION: us-east-1
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   blue-green-deploy:
@@ -34,12 +30,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+      - name: Assume Actions IAM Role  
+        uses: energyhub/workflow-actions/assume-actions-role@v2.4.2
 
       - name: Deploy to AWS ECS
         run: ./etc/ci/deploy.sh "${{ inputs.vpc }}" "${{ inputs.image-tag }}"

--- a/.github/workflows/maven-build-lifecycle.yml
+++ b/.github/workflows/maven-build-lifecycle.yml
@@ -5,10 +5,6 @@ on:
     secrets:
       JFROG_PASSWORD:
         required: true
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
     inputs:
       ecr-repository:
         description: "Amazon ECR repository name, e.g. 'energyhub/mec', 'energyhub/uwp'"
@@ -39,8 +35,9 @@ on:
         description: "The docker image tag"
         value: ${{ jobs.build-and-run-tests.outputs.image-tag }}
 
-env:
-  AWS_REGION: us-east-1
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   build-and-run-tests:
@@ -64,12 +61,8 @@ jobs:
         id: resolve-revision
         run: echo "revision=$(source ./etc/ci/get_revision.sh && get_revision .)" >> $GITHUB_OUTPUT
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
+      - name: Assume Actions IAM Role  
+        uses: energyhub/workflow-actions/assume-actions-role@v2.4.2
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
…al helper

Why this PR is needed
----
We need to update existing workflows to use the OIDC to auth to AWS IAM rather than continuing to rely on AWS credentials stored in GitHub secrets.

Jira ticket reference : [DEVOPS-1187](https://energyhub.atlassian.net/browse/DEVOPS-1187)

What this PR includes
----
Replacement of `aws-actions/configure-aws-credentials@v1-node16` with `energyhub/workflow-actions/assume-actions-role@v2.4.2` references.