### PR TITLE
CAT-82: update maven cache config

### DIFF
--- a/.github/actions/maven-setup/action.yml
+++ b/.github/actions/maven-setup/action.yml
@@ -17,13 +17,7 @@ runs:
       with:
         java-version: "17"
         distribution: "temurin"
-    - name: Cache local Maven repository
-      uses: actions/cache@v3
-      with:
-        path: $HOME/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        cache: "maven"
     - name: Generate settings.xml for Maven Builds
       shell: bash
       run: |


### PR DESCRIPTION
Why this PR is needed
----
Caching of Maven dependencies does not appear to have been working which makes builds slower.

Jira ticket reference : [CAT-82](https://energyhub.atlassian.net/browse/CAT-82)

What this PR includes
----
Updated the Maven cache configuration per https://github.com/actions/setup-java#caching-packages-dependencies

How to test / verify these changes
----
Use in a build and see that caches appear for that project.  Example link -> https://github.com/energyhub/base-pom/actions/caches