### PR TITLE
DEVOPS-1547 deploy EDX via gha from any repository

### DIFF
--- a/.github/workflows/infrautils-edx-deploy.yaml
+++ b/.github/workflows/infrautils-edx-deploy.yaml
@@ -1,7 +1,7 @@
 # This workflow installs infrautils (DevOps maintained infrastructure as service python package) from JFrog
 # and uses infrautils (boto3) to deploy a EDX via cloudformation stack update
 # https://github.com/energyhub/infra-utils
-name: Infrautils CFN Deploy
+name: Infrautils EDX CFN Deploy
 
 on:
   workflow_call:

--- a/.github/workflows/infrautils-edx-deploy.yaml
+++ b/.github/workflows/infrautils-edx-deploy.yaml
@@ -6,13 +6,9 @@ name: Infrautils CFN Deploy
 on:
   workflow_call:
     secrets:
-      JFROG_CI_PASSWORD:
+      JFROG_PYPI_PASSWORD:
         required: true
     inputs:
-      service:
-        description: "Name of the service to be deployed"
-        required: true
-        type: string
       image-tag:
         description: "Tag of the image to deploy"
         required: true
@@ -31,7 +27,6 @@ permissions:
 
 jobs:
   infrautils-cfn-deploy:
-    environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     name: infrautils-EDX-cfn-deploy
     steps:
@@ -46,7 +41,7 @@ jobs:
       - name: Install infrautils
         run: |
           pip install infrautils \
-            -i https://ci-infra-utils:${{ secrets.JFROG_PASSWORD }}@${{ env.JFROG_PYPI_URI }}
+            -i https://ci-infra-utils:${{ secrets.JFROG_PYPI_PASSWORD }}@${{ env.JFROG_PYPI_URI }}
       - name: Assume Actions IAM Role
         uses: energyhub/workflow-actions/assume-actions-role@v2.4.2
 

--- a/.github/workflows/infrautils-edx-deploy.yaml
+++ b/.github/workflows/infrautils-edx-deploy.yaml
@@ -1,0 +1,66 @@
+# This workflow installs infrautils (DevOps maintained infrastructure as service python package) from JFrog
+# and uses infrautils (boto3) to deploy a EDX via cloudformation stack update
+# https://github.com/energyhub/infra-utils
+name: Infrautils CFN Deploy
+
+on:
+  workflow_call:
+    secrets:
+      JFROG_CI_PASSWORD:
+        required: true
+    inputs:
+      service:
+        description: "Name of the service to be deployed"
+        required: true
+        type: string
+      image-tag:
+        description: "Tag of the image to deploy"
+        required: true
+        type: string
+      vpc:
+        description: "VPC to deploy to, e.g. 'prod', 'qa-1', 'mec-rc', etc."
+        required: true
+        type: string
+
+env:
+  JFROG_PYPI_URI: ehub.jfrog.io/artifactory/api/pypi/pypi-all/simple
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  infrautils-cfn-deploy:
+    environment: ${{ inputs.environment }}
+    runs-on: ubuntu-latest
+    name: infrautils-EDX-cfn-deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install infrautils
+        run: |
+          pip install infrautils \
+            -i https://ci-infra-utils:${{ secrets.JFROG_PASSWORD }}@${{ env.JFROG_PYPI_URI }}
+      - name: Assume Actions IAM Role
+        uses: energyhub/workflow-actions/assume-actions-role@v2.4.2
+
+      - name: Deploy via Cloudformation
+        run: |
+          infrautils cfn.deploy \
+            -s ${{ inputs.vpc }}-edx-ecs-tasks-and-services \
+            -e Env=${{ inputs.vpc }} \
+            -e ctpImageTag=${{ inputs.image-tag }} \
+            -e EnrollmentWorkerImageTag=${{ inputs.image-tag }} \
+            -e WorkhorseImageTag=${{ inputs.image-tag }} \
+            -e oadrvtnImageTag=${{ inputs.image-tag }} \
+            -e uwpImageTag=${{ inputs.image-tag }} \
+            -e ReportsImageTag=${{ inputs.image-tag }} \
+            -e PartnerAPIImageTag=${{ inputs.image-tag }} \
+            -e Sep2UtilityImageTag=${{ inputs.image-tag }} \
+            -e DeploymentRegister=$(date --iso-8601=seconds)


### PR DESCRIPTION
Why this PR is needed
----
The adds a gha workflow to deploy EDX from any repository. 

Note: this will by default use the previous template for EDX, so no EDX infrastructure deployments can be made using this workflow, this only will deploy an updated image tag.

Jira ticket reference : [DEVOPS-1547](https://energyhub.atlassian.net/browse/DEVOPS-1547)

Note: depends on https://github.com/energyhub/infra-utils/pull/280

[DEVOPS-1547]: https://energyhub.atlassian.net/browse/DEVOPS-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ