### PR TITLE
DEVOPS-1404 fixes to the infrautils-cfn-deploy workflow

### DIFF
--- a/.github/workflows/infrautils-cfn-deploy.yml
+++ b/.github/workflows/infrautils-cfn-deploy.yml
@@ -6,7 +6,7 @@ name: Infrautils CFN Deploy
 on:
   workflow_call:
     secrets:
-      JFROG_CI_PASSWORD:
+      JFROG_PYPI_PASSWORD:
         required: true
     inputs:
       service:
@@ -31,7 +31,6 @@ on:
         required: false
 
 env:
-  TEMPLATE_DIR: {{ inputs.templatedir || cloudformation/templates }}
   JFROG_PYPI_URI: ehub.jfrog.io/artifactory/api/pypi/pypi-all/simple
 
 permissions:
@@ -40,7 +39,6 @@ permissions:
 
 jobs:
   infrautils-cfn-deploy:
-    environment: ${{ inputs.environment }}
     runs-on: ubuntu-latest
     name: infrautils-cfn-deploy
     steps:
@@ -55,7 +53,7 @@ jobs:
       - name: Install infrautils
         run: |
           pip install infrautils \
-            -i https://ci-infra-utils:${{ secrets.JFROG_PASSWORD }}@${{ env.JFROG_PYPI_URI }}
+            -i https://ci-infra-utils:${{ secrets.JFROG_PYPI_PASSWORD }}@${{ env.JFROG_PYPI_URI }}
 
       - name: Assume Actions IAM Role
         uses: energyhub/workflow-actions/assume-actions-role@v2.4.2


### PR DESCRIPTION
Why this PR is needed
----

- In previous PR I missed removing the environment input reference (that @lainekendall pointed out)
- Also updated the JFROG_PASSWORD secret name to be clearer (and consistent across the whole file)
- GHA workflows doesn't seem to like my attempt to set a default for the cfn templates dir, so I'm removing that

Jira ticket reference : [DEVOPS-1404](https://energyhub.atlassian.net/browse/DEVOPS-1404)


[DEVOPS-1404]: https://energyhub.atlassian.net/browse/DEVOPS-1404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ