### PR TITLE
DEVOPS-1404 fix the templatedir argument on the infrautils deploy now…

### DIFF
--- a/.github/workflows/infrautils-cfn-deploy.yml
+++ b/.github/workflows/infrautils-cfn-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           infrautils cfn.deploy \
             -s ${{ inputs.vpc }}-${{ inputs.service }} \
-            -t ${{ env.TEMPLATE_DIR }}/${{ inputs.service }}.yaml \
+            -t ${{ inputs.templatedir }}/${{ inputs.service }}.yaml \
             -e Env=${{ inputs.vpc }}  \
             -e ImageTag=${{ inputs.image-tag }} \
             -e DeploymentRegister=$(date --iso-8601=seconds) \


### PR DESCRIPTION
… templatedir is only in inputs and not env

Why this PR is needed
----
Last PR removed the attempt to set a default templatedir in the gha workflow, but didn't update the args on the actual infrautils deploy to reference the inputs, not the env.

Jira ticket reference : [DEVOPS-1404](https://energyhub.atlassian.net/browse/DEVOPS-1404)


[DEVOPS-1404]: https://energyhub.atlassian.net/browse/DEVOPS-1404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ