### PR TITLE
MEC-1350 : Add session-duration-seconds option to aws-ecs-deploy

### DIFF
--- a/.github/workflows/aws-ecs-deploy.yml
+++ b/.github/workflows/aws-ecs-deploy.yml
@@ -16,6 +16,11 @@ on:
         description: "VPC to deploy to, e.g. 'prod', 'qa-1', 'mec-rc', etc."
         required: true
         type: string
+      session-duration-seconds:
+        description: "Session duration for assume actions role"
+        required: false
+        default: 3600
+        type: string
 
 permissions:
   contents: read
@@ -32,6 +37,8 @@ jobs:
 
       - name: Assume Actions IAM Role  
         uses: energyhub/workflow-actions/assume-actions-role@v2.4.2
+        with:
+          session-duration-seconds: ${{ inputs.session-duration-seconds }}
 
       - name: Deploy to AWS ECS
         run: ./etc/ci/deploy.sh "${{ inputs.vpc }}" "${{ inputs.image-tag }}"


### PR DESCRIPTION
Why this PR is needed
----
In MEC we are having problems with the cloudformation deployment taking more than one hour, resulting in the role timing out and showing the github action as failed even though it succeeded.  This adds the option to pass the session duration seconds when calling the workflow. 

Jira ticket reference : [MEC-1350](https://energyhub.atlassian.net/browse/MEC-1350)

What this PR includes
----
- Add session-duration-seconds option to deployment workflow

How to test / verify these changes
----
Can't really test this until it's out

[MEC-1350]: https://energyhub.atlassian.net/browse/MEC-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ