### PR TITLE
MEC-1350 : Use recent version of assume-actions-role

### DIFF
--- a/.github/workflows/aws-ecs-deploy.yml
+++ b/.github/workflows/aws-ecs-deploy.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Assume Actions IAM Role  
-        uses: energyhub/workflow-actions/assume-actions-role@v2.4.2
+        uses: energyhub/workflow-actions/assume-actions-role@v2.5.0
         with:
           session-duration-seconds: ${{ inputs.session-duration-seconds }}
 


### PR DESCRIPTION
Why this PR is needed
----
the duration is not supported in the lower versions.

Jira ticket reference : [MEC-1350](https://energyhub.atlassian.net/browse/MEC-1350)

What this PR includes
----
increase version of assume-actions-role to release 1.5.0

[MEC-1350]: https://energyhub.atlassian.net/browse/MEC-1350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ