### PR TITLE
DEVOPS-1775 parametrizing the infrautils template path

### DIFF
--- a/.github/workflows/infrautils-microservice-s3-deploy.yml
+++ b/.github/workflows/infrautils-microservice-s3-deploy.yml
@@ -22,6 +22,11 @@ on:
         description: "VPC to deploy to, e.g. 'prod', 'qa-1', 'mec-rc', etc."
         required: true
         type: string
+      template-path:
+        description: "The path to the template file inside of the cloudformation project"
+        required: false
+        type: string
+        default: "microservices/ecs-alb-microservice.yaml"
       parameter-overrides:
         description: "Any additional parameter overrides, e.g. '-e DesiredTasks=6 -e TaskMem=4096'"
         type: string
@@ -59,7 +64,7 @@ jobs:
         run: |
           infrautils cfn.deploy \
             -s ${{ inputs.vpc }}-${{ inputs.service }} \
-            -t https://infradata.s3.amazonaws.com/cloudformation/templates/microservices/ecs-alb-microservice.yaml \
+            -t https://infradata.s3.amazonaws.com/cloudformation/templates/${{ inputs.template-path }} \
             -r deploy-${{ inputs.service }}-role \
             -e Env=${{ inputs.vpc }}  \
             -e ImageTag=${{ inputs.image-tag }} \


### PR DESCRIPTION
Why this PR is needed
----
While working on `DEVOPS-1775` it turned out it would be neat to have an option to provide an alternative template to the `.github/workflows/infrautils-microservice-s3-deploy.yml`.

Jira ticket reference : [DEVOPS-1775](https://energyhub.atlassian.net/browse/DEVOPS-1775)

What this PR includes
----
Adding an option to provide an alternative template to the `.github/workflows/infrautils-microservice-s3-deploy.yml`. Tested out and confirmed to work in [this run](https://github.com/energyhub/azure-adapter/actions/runs/5043558547/jobs/9045516900).

[DEVOPS-1775]: https://energyhub.atlassian.net/browse/DEVOPS-1775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ