### PR TITLE
CAT-151 - Allow Maven Setup Action to specify JDK version

### DIFF
--- a/.github/actions/maven-setup/action.yml
+++ b/.github/actions/maven-setup/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Maven"
-description: "Setup JDK 17, maven cache, and JFrog credentials"
+description: "Setup JDK (defaults to 17), Maven cache, and JFrog credentials."
 
 inputs:
   jfrog-user:
@@ -8,14 +8,17 @@ inputs:
   jfrog-password:
     description: JFrog access key (password)
     required: true
+  jdk-version:
+    description: The JDK version to use
+    default: "17"
 
 runs:
   using: composite
   steps:
-    - name: Set up JDK 17
+    - name: Set up JDK ${inputs.jdk-version}
       uses: actions/setup-java@v3
       with:
-        java-version: "17"
+        java-version: ${inputs.jdk-version}
         distribution: "temurin"
         cache: "maven"
     - name: Generate settings.xml for Maven Builds

--- a/.github/actions/maven-setup/action.yml
+++ b/.github/actions/maven-setup/action.yml
@@ -15,10 +15,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Set up JDK ${inputs.jdk-version}
+    - name: Set up JDK ${{ inputs.jdk-version }}
       uses: actions/setup-java@v3
       with:
-        java-version: ${inputs.jdk-version}
+        java-version: ${{ inputs.jdk-version }}
         distribution: "temurin"
         cache: "maven"
     - name: Generate settings.xml for Maven Builds


### PR DESCRIPTION
Why this PR is needed
----
In some cases we need to build against different JDK versions.  The previous version of this did not allow changing this. Working with the [eh-protos](https://github.com/energyhub/eh-protos) is one such example because its Java artifacts are used by both EDX (uses JDK 11) and the new microservices (uses JDK 17).

Jira ticket reference : [CAT-151](https://energyhub.atlassian.net/browse/CAT-151)

What this PR includes
----
Add a jdk-version input to the action. If one is not specified Java 17 is used.

How to test / verify these changes
----
See https://github.com/energyhub/eh-protos/pull/72/files#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434 for test and usage example.

[CAT-151]: https://energyhub.atlassian.net/browse/CAT-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ