### PR TITLE
PIT-1178 : Update year in copyright

### DIFF
--- a/copyright/copyright-xml.txt
+++ b/copyright/copyright-xml.txt
@@ -1,3 +1,3 @@
 <!--
-    Copyright © 2022 EnergyHub, Inc. All Rights Reserved.
+    Copyright © 2025 EnergyHub, Inc. All Rights Reserved.
 -->


### PR DESCRIPTION
This copyright is used in the XSD used by MEC for its enrollments.

Jira ticket reference : [PIT-1178](https://energyhub.atlassian.net/browse/PIT-1178)

The XSD is publicly available at
https://s3.amazonaws.com/net.energyhub.assets/public/mec/mec-enrollment-1.84.0.xsd but currently contains a 2022 copyright.

Tests:
- N/A


[PIT-1178]: https://energyhub.atlassian.net/browse/PIT-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ