### PR TITLE
PIT-1252: Update PR template and CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,4 +13,4 @@
 # whenever someone makes a PR in this repo. This file does
 # not make it so that someone from the maintainer group
 # must approve the PR, despite Github hinting otherwise!
-* @energyhub/architecture
+* @energyhub/ground-control

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,13 +1,31 @@
-Why this PR is needed
-----
-Add a sentence or two on the reason this PR exists. Remember that the reviewer likely doesn't have as much context as you. Help them help you.
+<!-- @formatter:off -->
 
-Jira ticket reference : [PROJECT-XXX](https://energyhub.atlassian.net/browse/PROJECT-XXX)
+Why this PR is needed
+---------------------
+<!-- Add a sentence or two on the reason this PR exists. Remember that the reviewer likely doesn't have as much context as you. Help them help you. -->
+
+
+<!-- Github will auto-link to Jira if configured in repo settings -> Autolink References --> 
+Jira ticket reference: PRJ-XXX
 
 What this PR includes
-----
-Brief description of what was done to meet the PR goal.
+---------------------
+<!-- Brief description of what was done to meet the PR goal. -->
+
+
 
 How this change was tested
-----
-Describe testing done on the change, or why this is not applicable.
+--------------------------
+<!-- Describe testing done on the change, or why this is not applicable. -->
+
+
+
+<!--
+Did You Think About
+------------------
+- Monitoring?
+- Metrics and logging to diagnose problems?
+- Documentation?
+-->
+
+<!-- @formatter:on -->


### PR DESCRIPTION
### This is the exact same as #47, I'm resubmitting it because the Validate PR Title action got "stuck" on that PR so I can't merge it.

<!-- @formatter:off -->

Why this PR is needed
---------------------
<!-- Add a sentence or two on the reason this PR exists. Remember that the reviewer likely doesn't have as much context as you. Help them help you. -->

We fill out a lot of PR templates. It would be nice if that was faster. 

Jira ticket reference: PIT-1252
(the above Jira ticket would be auto-linked if this repo was configured for PIT-project tickets)

What this PR includes
---------------------
<!-- Brief description of what was done to meet the PR goal. -->

New PR template:
- Use HTML comments for instructions to the submitter, so that you don't have to bother deleting them when filling out the PR
- Use Github auto-linking for Jira ticket references, to remove one place to set the ticket number
- Add some "things to think about" in comments at the end

Also updated CODEOWNERS for this repo to GC, instead of architecture.

How this change was tested
--------------------------
<!-- Describe testing done on the change, or why this is not applicable. -->

Created this PR! 😁 
This PR description is made with the new template - you can hit the "edit" to see how it was filled out.

<!--
Did You Think About
------------------
- Monitoring?
- Metrics and logging to diagnose problems?
- Documentation?
-->

<!-- @formatter:on -->
